### PR TITLE
Fixed buzzing timer

### DIFF
--- a/client/js/main.js
+++ b/client/js/main.js
@@ -75,7 +75,7 @@ var vm = new Vue({
                 this.canBuzz = true;
                 this.focused = true;
                 this.pause = true;
-                if (this.timerBuffer < 0) { this.timerBuffer = 50; }
+                this.timerBuffer = 50;
                 this.timesBuzzed++;
             }
         },


### PR DESCRIPTION
This way, when you buzz, you are always given five seconds, not three if
the tossup is over.
